### PR TITLE
declare crate to be `no_std`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs, missing_debug_implementations)]
 


### PR DESCRIPTION
looks like `branches` was taken from `rclite` where it benefited from the crate's `no_std` declaration. after becoming its own crate, it appears we need to declare it as `no_std` in order to allow usage in `no_std` projects. it happened to me  that the crate won't build within my `no_std` project because it wasn't declared to be compatible.